### PR TITLE
Explicitly add -std=c++17 to build systems

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 # General compiler arguments
 CXX = clang++
-CXXFLAGS = -g -fstandalone-debug -O0 -Wall -Wextra -pedantic-errors -Wc++20-designator
+CXXFLAGS = -g -fstandalone-debug -O0 -Wall -Wextra -pedantic-errors -Wc++20-designator -std=c++17
 # CXXFLAGS = -O3 -Wall -Wextra -pthread -pedantic-errors -std=c++2c
 
 # Files to compile

--- a/quickbuild
+++ b/quickbuild
@@ -1,7 +1,7 @@
 # general compiler arguments.
 compiler = "clang++";
-flags_debug = "-g -O0 -fstandalone-debug -Wall -Wextra -pedantic-errors -Wc++20-designator";
-flags_release = "-O3 -fstandalone-debug -Wall -Wextra -pedantic-errors -Wc++20-designator";
+flags_debug = "-g -O0 -fstandalone-debug -Wall -Wextra -pedantic-errors -Wc++20-designator -std=c++17";
+flags_release = "-O3 -fstandalone-debug -Wall -Wextra -pedantic-errors -Wc++20-designator -std=c++17";
 
 # files to compile.
 sources = "src/*.cpp";


### PR DESCRIPTION
The templates `std::optional` and `std::variant` does not exist in c++ versions before c++17. Therefore trying to build the `dev` version right now causes a crash. This pr adds that flag to the quickbuild file and to the makefile.